### PR TITLE
Fetch, Cache and Clean up

### DIFF
--- a/demo/src/rise-data-weather.html
+++ b/demo/src/rise-data-weather.html
@@ -40,21 +40,35 @@
     >
   </rise-data-weather>
 
+  <ul id="log">
+  </ul>
+
   <script>
+    function log(text) {
+      console.log(text);
+      var ul = document.getElementById("log");
+      var li = document.createElement("li");
+      li.appendChild(document.createTextNode(text));
+      ul.appendChild(li);
+    }
+
     function configureComponents() {
       const start = new CustomEvent( "start" ),
         weather01 = document.querySelector('#rise-data-weather-01');
 
       weather01.addEventListener( "data-update", ( evt ) => {
         console.log( "data update", JSON.stringify(evt.detail) );
+        log(JSON.stringify(evt.detail));
       } );
 
       weather01.addEventListener( "data-error", ( evt ) => {
-        console.log( "data error", evt.detail );
+        console.log( "data error", JSON.stringify(evt.detail) );
+        log(JSON.stringify(evt.detail));
       } );
 
       weather01.addEventListener( "request-error", ( evt ) => {
-        console.log( "request error", evt.detail );
+        console.log( "request error", JSON.stringify(evt.detail) );
+        log(JSON.stringify(evt.detail));
       } );
 
       // Uncomment the following line if the weather component is marked as non-editable

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prebuild": "eslint . && ./create_config.sh prod",
     "build": "polymer build && ./node_modules/common-component/extract-source.sh rise-data-weather",
     "pretest": "eslint . && ./create_config.sh test",
-    "test": "polymer test"
+    "test": "polymer test",
+    "pretty": "eslint . --fix"
   },
   "repository": {
     "type": "git",

--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -168,7 +168,7 @@ class RiseDataWeather extends PolymerElement {
         this._handleResponse( res.clone());
         return cache.put( res.url, res );
       })
-    });
+    }).catch( this._handleFetchError.bind( this ));
   }
 
   _handleStart() {
@@ -209,8 +209,8 @@ class RiseDataWeather extends PolymerElement {
     });
   }
 
-  _handleResponseError( event, request ) {
-    this._log( "error", "error response", { response: request.response });
+  _handleFetchError() {
+    this._log( "error", "request error" );
     this._sendWeatherEvent( RiseDataWeather.EVENT_REQUEST_ERROR );
   }
 


### PR DESCRIPTION
As part of Cache API tests in Electron, I had to change the request mechanism to use fetch() instead of iron-ajax. XMLHTTPRequest can't be stored in Cache API.

Since I had to implement caching for the tests, I organized it and decided to open this PR as it is a good basis for the final implementation.

I also cleaned up the code a little bit and created a simple demo Template.

@alex-deaconu Please review. Thanks!

