### PR TITLE
Allow displayAddress attribute to be set externally

### DIFF
--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -25,8 +25,7 @@ class RiseDataWeather extends CacheMixin( PolymerElement ) {
        * The address of the display running this instance of the component.
        */
       displayAddress: {
-        type: Object,
-        readOnly: true
+        type: Object
       },
 
       /**


### PR DESCRIPTION
Allow displayAddress attribute to be set externally, namely by Template Editor Preview.