### PR TITLE
E2e/deploy to versioned path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,20 @@
 version: 2.1
 
 jobs:
-  install:
+  preconditions:
     docker: &BUILDIMAGE
       - image: jenkinsrise/cci-v2-components:0.0.5
+    steps:
+      - checkout
+      - run: |
+          if [ -z $(grep version package.json |grep -o '[0-9.]*') ]
+          then
+            echo Version must be specified in package.json
+            exit 1
+          fi
+
+  install:
+    docker: *BUILDIMAGE
     steps:
       - checkout
       - restore_cache:
@@ -84,8 +95,6 @@ jobs:
           sed "
             s/__STAGE__/<< parameters.stage >>/;
             s/__VERSION__/$VERSION/;
-            s/__PLAYER__/electron/;
-            s/__CONNECTION__/websocket/;
           " e2e/rise-data-weather.html > e2e/rise-data-weather-electron.html
       - run: cp e2e/polymer-e2e-electron.json polymer.json
       - run: polymer build
@@ -189,27 +198,37 @@ jobs:
       - run: cp -r gcloud ~/.config
       - run: npm install common-component
       - run: |
-          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/rise-data-weather/
-          echo Deploying << parameters.stage >> version of rise-data-weather
+          MAJOR=$(grep version package.json | grep -Po '[0-9]+' | head -1)
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/rise-data-weather/$MAJOR/
+          echo Deploying << parameters.stage >> version of rise-data-weather/$MAJOR
           node_modules/common-component/deploy-gcs.sh rise-data-weather $TARGET
 
 workflows:
   workflow1:
     jobs:
-      - install
+      - preconditions
+      - install:
+          requires:
+            - preconditions
       - gcloud-setup:
+          requires:
+            - preconditions
           filters:
             branches:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - generate-version:
+          requires:
+            - preconditions
           filters:
             branches:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - test:
           requires:
@@ -223,6 +242,7 @@ workflows:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - build-e2e-page:
           stage: beta
@@ -233,6 +253,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -251,6 +272,7 @@ workflows:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - deploy-e2e-page:
           stage: beta
@@ -262,6 +284,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -283,6 +306,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - test-e2e-electron:
           displayId: PX6NQHW8R973
           installerPath: /

--- a/demo/src/rise-data-weather.html
+++ b/demo/src/rise-data-weather.html
@@ -18,7 +18,7 @@
   </script>
   <script src="https://widgets.risevision.com/beta/common/config-test.min.js"></script>
   <script src="https://widgets.risevision.com/beta/common/common-template.min.js"></script>
-  <script src="https://widgets.risevision.com/beta/components/rise-data-weather/rise-data-weather.js"></script>
+  <script src="https://widgets.risevision.com/beta/components/rise-data-weather/1/rise-data-weather.js"></script>
   <script>
     if (document.domain.indexOf("localhost") === -1) {
       try {

--- a/e2e/rise-data-weather.html
+++ b/e2e/rise-data-weather.html
@@ -77,18 +77,7 @@
       } );
     </script>
     <script>
-      // electron / websocket or chromeos / window
-      RisePlayerConfiguration.configure({
-        displayId: "Y8SAH3CQ6NMP",
-        companyId: "7fa5ee92-7deb-450b-a8d5-e5ed648c575f",
-        playerType: "__STAGE__",
-        playerVersion: "TEST_VERSION",
-        os: "TEST_OS"
-      }, {
-        player: "__PLAYER__",
-        connectionType: "__CONNECTION__",
-        detail: { serverUrl: "http://localhost:8080" }
-      });
+      RisePlayerConfiguration.configure();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Changes to deploy to versioned path as mentioned here: Rise-Vision/rise-image#8

E2E tests successful with this changes: https://circleci.com/workflow-run/99849521-5790-436b-8678-bd50d9364fb8

I tested deployment, and the beta script is being generated as expected here:
https://console.cloud.google.com/storage/browser/widgets.risevision.com/beta/components/rise-data-weather/1/?project=avid-life-623&pli=1

I also did some simplifications to the e2e page configuration and page build, as some fixed parameters are needed for rise-data-financial / financial selector, but not for this component.

Also, I notice that iron-ajax is set as a dependency in package.json:
https://github.com/Rise-Vision/rise-data-weather/blob/master/package.json#L30

but I saw no usage of it in the code, so I'm not considering it now as a dependency to be exported, at least currently.
