### PR TITLE
Always store screenshots in artifacts even when tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,10 +178,14 @@ jobs:
           name: run the test
           working_directory: rise-launcher-electron-e2e
           command: node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
-      - run: mkdir output
-      - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
+      - run:
+          command: |
+            mkdir output
+            mv ./rise-launcher-electron-e2e/*screenshot.jpg output
+          when: always
       - store_artifacts:
           path: output
+          when: always
 
   deploy-production:
     parameters:


### PR DESCRIPTION
As per https://github.com/Rise-Vision/rise-slides/pull/19/commits/26ab2369587b4795a2ea7ae55e4ba40cd9c7bc2e

@ezequielc please review. Thanks!