### PR TITLE
Set data refresh timer to 30 minutes

### DIFF
--- a/demo/src/rise-data-weather-dev.html
+++ b/demo/src/rise-data-weather-dev.html
@@ -36,7 +36,7 @@
   window.RisePlayerConfiguration = {
     onDisplayDataCallback: null,
     isConfigured: function(){return false},
-    isPreview: function(){return true},
+    isPreview: function(){return false},
     getDisplayId: function(){return 'DisplayID'},
     DisplayData: {
       onDisplayData: function(callback){

--- a/demo/src/rise-data-weather-dev.html
+++ b/demo/src/rise-data-weather-dev.html
@@ -36,6 +36,7 @@
   window.RisePlayerConfiguration = {
     onDisplayDataCallback: null,
     isConfigured: function(){return false},
+    isPreview: function(){return true},
     getDisplayId: function(){return 'DisplayID'},
     DisplayData: {
       onDisplayData: function(callback){

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-refresh"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.0"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.3"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.13"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.13"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-refresh"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -69,10 +69,14 @@ class RiseDataWeather extends FetchMixin( fetchBase ) {
     super.ready();
 
     super.initFetch({
-      refresh: 1000 * 60 * 30
+      retry: 1000 * 60,
+      cooldown: 1000 * 60 * 10,
+      refresh: 1000 * 60 * 30,
+      count: 5
     }, this._handleResponse, this._handleError );
     super.initCache({
-      name: this.tagName.toLowerCase()
+      name: this.tagName.toLowerCase(),
+      expiry: 1000 * 60 * 60 * 2      
     });
   }
 

--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -68,7 +68,9 @@ class RiseDataWeather extends FetchMixin( fetchBase ) {
   ready() {
     super.ready();
 
-    super.initFetch({}, this._handleResponse, this._handleError );
+    super.initFetch({
+      refresh: 1000 * 60 * 30
+    }, this._handleResponse, this._handleError );
     super.initCache({
       name: this.tagName.toLowerCase()
     });

--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -76,7 +76,7 @@ class RiseDataWeather extends FetchMixin( fetchBase ) {
     }, this._handleResponse, this._handleError );
     super.initCache({
       name: this.tagName.toLowerCase(),
-      expiry: 1000 * 60 * 60 * 2      
+      expiry: 1000 * 60 * 60 * 2
     });
   }
 

--- a/test/unit/rise-data-weather.html
+++ b/test/unit/rise-data-weather.html
@@ -65,7 +65,7 @@
       fetchMixin.initFetch({
         retry: 1000 * 60,
         cooldown: 1000 * 60 * 10,
-        refresh: 1000 * 60 * 60,
+        refresh: 1000 * 60 * 30,
         count: 5
       }, handleResponse, handleError );
     });
@@ -341,8 +341,12 @@
     suite( "_getData", () => {
       test( "should get the result from cache", done => {
         sandbox.stub(cacheMixin, "getCache").resolves({
-          text: () => {
-            return Promise.resolve("text");
+          clone: () => {
+            return {
+              text: () => {
+                return Promise.resolve("text");
+              }
+            };
           }
         });
         sandbox.stub(element, "_processWeatherData");
@@ -613,7 +617,7 @@
         });
       });
 
-      test( "should enqueue next request for 1 hour", done => {
+      test( "should enqueue next request for 30 minutes", done => {
         sandbox.stub(cacheMixin, "getCache").rejects();
         sandbox.stub(cacheMixin, "putCache").resolves();
         sandbox.stub(fetchMixin, "_refresh");
@@ -623,7 +627,7 @@
         element.addEventListener("data-update", () => {
           setTimeout(() => {
             assert.isTrue( fetchMixin._refresh.called );
-            assert.isTrue( fetchMixin._refresh.calledWith(60 * 60 * 1000));
+            assert.isTrue( fetchMixin._refresh.calledWith(30 * 60 * 1000));
 
             done();            
           }, 10);
@@ -662,7 +666,7 @@
         element.addEventListener("data-error", evt => {
           setTimeout(() => {
             assert.isTrue( fetchMixin._refresh.called );
-            assert.isTrue( fetchMixin._refresh.calledWith(60 * 60 * 1000));
+            assert.isTrue( fetchMixin._refresh.calledWith(30 * 60 * 1000));
 
             done();            
           }, 10);


### PR DESCRIPTION
## Description
Set data refresh timer to 30 minutes

Update common-template version

Fix unit tests
Fix demo page

## Motivation and Context
More frequent refreshes for weather data should better cover weather variations during the day

## How Has This Been Tested?
Updated unit test coverage
Tested locally

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
