### PR TITLE
Updated cacheMixin version falls back to localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-fallback"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.2.0"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.0"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-fallback"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",


### PR DESCRIPTION
## Description
Updated cacheMixin version falls back to localStorage

## Motivation and Context
Fixes issue where cache is not available in http

## How Has This Been Tested?
Validated on both local environment and Chrome OS

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
