### PR TITLE
Always log content on data error

### DIFF
--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -168,7 +168,7 @@ class RiseDataWeather extends FetchMixin( fetchBase ) {
 
       this._sendWeatherEvent( RiseDataWeather.EVENT_DATA_UPDATE, this.weatherData );
     } catch ( e ) {
-      super.log( RiseDataWeather.LOG_TYPE_ERROR, "data error", { error: e.message });
+      super.log( RiseDataWeather.LOG_TYPE_ERROR, "data error", { error: e.message, content: content });
 
       this._sendWeatherEvent( RiseDataWeather.EVENT_DATA_ERROR, e );
     }

--- a/src/tinbu-parser.js
+++ b/src/tinbu-parser.js
@@ -55,7 +55,7 @@ function validateData( body, xmlDoc ) {
     if ( error !== null ) {
       throw new Error( error.textContent );
     } else {
-      throw new Error( `Report data is missing (${body})` );
+      throw new Error( "Report data is missing" );
     }
   }
   return report;

--- a/test/unit/rise-data-weather.html
+++ b/test/unit/rise-data-weather.html
@@ -648,7 +648,7 @@
 
           assert.isTrue( loggerMixin.log.calledTwice );
           assert.deepEqual( loggerMixin.log.getCall(0).args, ["info", "data received", {cached: false}] );
-          assert.deepEqual( loggerMixin.log.getCall(1).args, ["error", "data error", {error: "Invalid weather report (Error: Report data is missing (<invalid/>))"}] );
+          assert.deepEqual( loggerMixin.log.getCall(1).args, ["error", "data error", {error: "Invalid weather report (Error: Report data is missing)", content: "<invalid/>"}] );
       
           done();
         });

--- a/test/unit/tinbu-parser.html
+++ b/test/unit/tinbu-parser.html
@@ -59,9 +59,9 @@
       });
 
       test( "should throw error on invalid data" , () => {
-        assert.throws(() => tinbu.parseTinbu("<incorrext-xml/>"), "Invalid weather report (Error: Report data is missing (<incorrext-xml/>))");
-        assert.throws(() => tinbu.parseTinbu(null), "Invalid weather report (Error: Report data is missing (null))");
-        assert.throws(() => tinbu.parseTinbu(), "Invalid weather report (Error: Report data is missing (undefined))");
+        assert.throws(() => tinbu.parseTinbu("<incorrext-xml/>"), "Invalid weather report (Error: Report data is missing)");
+        assert.throws(() => tinbu.parseTinbu(null), "Invalid weather report (Error: Report data is missing)");
+        assert.throws(() => tinbu.parseTinbu(), "Invalid weather report (Error: Report data is missing)");
         assert.throws(() => tinbu.parseTinbu("<report></report>"), "Invalid weather report (Error: Observation data is missing)");
         assert.throws(() => tinbu.parseTinbu("<report><observation/></report>"), "Invalid weather report (Error: Location data is missing)");
         assert.throws(() => tinbu.parseTinbu("<report><location></location></report>"), "Invalid weather report (Error: Observation data is missing)");


### PR DESCRIPTION
## Description
Always log content on data error

## Motivation and Context
Help debug issues with responses from Tinbu and/or Proxy server.

## How Has This Been Tested?
Updated unit tests. Tested locally by generating a content error.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
