### PR TITLE
Encode address parameter twice for API

### DIFF
--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -161,7 +161,7 @@ class RiseDataWeather extends FetchMixin( fetchBase ) {
     let url = weatherServerConfig.providerURL;
 
     url += "&metric=" + ( this.scale == "C" ? "true" : "false" );
-    url += "&name=" + encodeURIComponent( this.fullAddress );
+    url += "&name=" + encodeURIComponent( encodeURIComponent( this.fullAddress ));
 
     return url;
   }


### PR DESCRIPTION
## Description
Encode address parameter twice for API

It seems to fix incorrect address matches
for some locations

## Motivation and Context
Fix for #60 as well as other addresses that were returning results from the wrong location

## How Has This Been Tested?
Validated the staging version with Charles proxy.
Tested address mentioned in the issue and the addresses we had noticed inconsistencies with in the past. All addresses returned the correct location with this change.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No