### PR TITLE
Fix issue 84

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-weather",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-weather",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Web component for retrieving weather data on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-weather",

--- a/src/rise-data-weather.js
+++ b/src/rise-data-weather.js
@@ -235,7 +235,7 @@ class RiseDataWeather extends FetchMixin( fetchBase ) {
     if ( resp.url.includes( "&product=search" )) {
       resp.text().then( this._processSearchData.bind( this ));
 
-    } else {
+    } else if ( resp.url.includes( "&product=current_extended" )) {
       resp.text().then( this._processWeatherData.bind( this, resp ));
     }
   }


### PR DESCRIPTION
## Description

- Fix for #84
- The problem is cause by `resp.url` returning `":"` [here](https://github.com/Rise-Vision/rise-data-weather/compare/stage/fix-issue-84?expand=1#diff-55697b59ecc361004779fd84ad4b1cc8c4dcff3cdc9d253b74bce63300b5d2e1R238). I can't reproduce it and not sure why `resp.url` returns incorrect url. Comparing `resp.url` against expected value should fixes the issue.

## Motivation and Context
Fix issue.

## How Has This Been Tested?
Tested locally using Charles proxy and confirmed that weather data (cached and not cached) is loaded and processed correctly.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
